### PR TITLE
build: ignore `.venv`, `__pycache__` directories, and `.pyc` files, and the `model` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Python
+.venv/
+__pycache__/
+*.pyc
+
+# model
+/model/


### PR DESCRIPTION
GitIgnore these Python runtime files that are present in the repo.

Also gitignore the `model` directory that is used to store the models.